### PR TITLE
feat: add provider aliases

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -41,6 +41,11 @@ module "ec2" {
 module "rds" {
   source = "./modules/rds"
 
+  providers = {
+    aws.source = aws.source
+    aws.target = aws.target
+  }
+
   project_name       = var.project_name
   vpc_id             = module.vpc.vpc_id
   private_subnet_ids = module.vpc.private_subnet_ids

--- a/terraform.tf
+++ b/terraform.tf
@@ -26,3 +26,15 @@ provider "aws" {
     }
   }
 }
+
+provider "aws" {
+  alias   = "source"
+  region  = var.aws_region
+  profile = "source"
+}
+
+provider "aws" {
+  alias   = "target"
+  region  = var.aws_region
+  profile = "target"
+}


### PR DESCRIPTION
## Summary
- add AWS provider aliases for source and target
- pass aliased providers to the RDS module

## Testing
- `terraform fmt -check` *(fails: command not found)*
- `terraform validate` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c1239e308327aeff38d8a8a9d592