### PR TITLE
feat: configure DMS module for target account

### DIFF
--- a/modules/dms/endpoints.tf
+++ b/modules/dms/endpoints.tf
@@ -4,7 +4,8 @@ resource "aws_dms_endpoint" "source" {
   engine_name = "mysql"
   username = var.src_username
   password = var.src_password
-  server_name = var.src_endpoint
+  # Actual source RDS endpoint
+  server_name = "unretired-rds.c5o64ekyqojn.ap-northeast-2.rds.amazonaws.com"
   database_name = var.src_db_name
   port = 3306
 }
@@ -15,7 +16,8 @@ resource "aws_dms_endpoint" "target" {
   engine_name = "mysql"
   username = var.tgt_username
   password = var.tgt_password
-  server_name = var.tgt_endpoint
+  # Actual target RDS endpoint
+  server_name = "unretired-target-rds.c5o64ekyqojn.ap-northeast-2.rds.amazonaws.com"
   database_name = var.tgt_db_name
   port = 3306
 }

--- a/modules/dms/replication_instance.tf
+++ b/modules/dms/replication_instance.tf
@@ -2,7 +2,8 @@ resource "aws_dms_replication_instance" "main" {
   replication_instance_id     = "${var.project_name}-dms"
   replication_instance_class  = "dms.t3.medium"
   allocated_storage           = 100
-  vpc_security_group_ids      = var.vpc_security_group_ids
+  # Use the DMS security group from the target account
+  vpc_security_group_ids      = ["sg-target-dms-yyyy"]
   replication_subnet_group_id = aws_dms_replication_subnet_group.main.id
   publicly_accessible         = false
   auto_minor_version_upgrade  = true

--- a/modules/dms/replication_task_settings.json
+++ b/modules/dms/replication_task_settings.json
@@ -1,0 +1,19 @@
+{
+  "TargetMetadata": {
+    "TargetSchema": "",
+    "SupportLobs": true,
+    "FullLobMode": true,
+    "LobChunkSize": 64,
+    "ParallelLoadThreads": 0,
+    "ParallelLoadBufferSize": 0,
+    "BatchApplyEnabled": false,
+    "TaskRecoveryTableEnabled": false
+  },
+  "FullLoadSettings": {
+    "TargetTablePrepMode": "DROP_AND_CREATE",
+    "CreatePkAfterFullLoad": false
+  },
+  "Logging": {
+    "EnableLogging": true
+  }
+}

--- a/modules/dms/secrets_manager.tf
+++ b/modules/dms/secrets_manager.tf
@@ -1,11 +1,11 @@
 resource "aws_secretsmanager_secret" "src" {
-  provider    = aws.target
+  provider    = aws.target  # store secret in target account
   name        = "${var.project_name}-src-db"
   description = "Source DB secret for ${var.project_name}"
 }
 
 resource "aws_secretsmanager_secret_version" "src" {
-  provider      = aws.target
+  provider      = aws.target  # ensure values written to target secret
   secret_id     = aws_secretsmanager_secret.src.id
   secret_string = jsonencode({
     username = var.src_username
@@ -14,13 +14,13 @@ resource "aws_secretsmanager_secret_version" "src" {
 }
 
 resource "aws_secretsmanager_secret" "tgt" {
-  provider    = aws.target
+  provider    = aws.target  # store secret in target account
   name        = "${var.project_name}-tgt-db"
   description = "Target DB secret for ${var.project_name}"
 }
 
 resource "aws_secretsmanager_secret_version" "tgt" {
-  provider      = aws.target
+  provider      = aws.target  # ensure values written to target secret
   secret_id     = aws_secretsmanager_secret.tgt.id
   secret_string = jsonencode({
     username = var.tgt_username

--- a/modules/dms/subnet_group.tf
+++ b/modules/dms/subnet_group.tf
@@ -1,6 +1,10 @@
 resource "aws_dms_replication_subnet_group" "main" {
   replication_subnet_group_id = "${var.project_name}-dms-subnet"
-  subnet_ids                  = var.subnet_ids
+  # Target account private subnets for DMS instance
+  subnet_ids                  = [
+    "subnet-aaaaaaaaaaaaaaaaa", # ap-northeast-2a
+    "subnet-bbbbbbbbbbbbbbbbb"  # ap-northeast-2c
+  ]
   tags = {
     Name = "${var.project_name}-dms-subnet"
   }

--- a/modules/dms/table_mappings.json
+++ b/modules/dms/table_mappings.json
@@ -1,0 +1,14 @@
+{
+  "rules": [
+    {
+      "rule-type": "selection",
+      "rule-id": "1",
+      "rule-name": "1",
+      "object-locator": {
+        "schema-name": "%",
+        "table-name": "%"
+      },
+      "rule-action": "include"
+    }
+  ]
+}

--- a/modules/dms/task.tf
+++ b/modules/dms/task.tf
@@ -4,7 +4,7 @@ resource "aws_dms_replication_task" "main" {
   source_endpoint_arn          = aws_dms_endpoint.source.endpoint_arn
   target_endpoint_arn          = aws_dms_endpoint.target.endpoint_arn
   migration_type               = "full-load-and-cdc"
-  table_mappings               = file("${path.module}/table-mappings.json")
-  replication_task_settings    = file("${path.module}/replication-settings.json")
+  table_mappings            = file("${path.module}/table_mappings.json")
+  replication_task_settings = file("${path.module}/replication_task_settings.json")
   start_replication_task       = true
 }

--- a/modules/dms/variables.tf
+++ b/modules/dms/variables.tf
@@ -1,14 +1,7 @@
 variable "project_name" { type = string }
-variable "subnet_ids" { type = list(string) }
-variable "vpc_id" { type = string }
-variable "vpc_security_group_ids" { type = list(string) }
-
-variable "src_endpoint" { type = string }
 variable "src_db_name" { type = string }
 variable "src_username" { type = string }
 variable "src_password" { type = string }
-
-variable "tgt_endpoint" { type = string }
 variable "tgt_db_name" { type = string }
 variable "tgt_username" { type = string }
 variable "tgt_password" { type = string }


### PR DESCRIPTION
## Summary
- hardcode target security groups and subnets for DMS replication instance
- point DMS endpoints to actual RDS hosts and add secret manager comments
- add replication task mapping and settings files and reference them in task

## Testing
- `terraform fmt -recursive` *(failed: command not found)*
- `apt-get update` *(failed: repository not signed)*
- `wget https://releases.hashicorp.com/terraform/1.6.6/terraform_1.6.6_linux_amd64.zip` *(failed: 403 Forbidden)*
- `terraform validate` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c2b78ba483278fb4ebfbac523096