### PR TITLE
Add target secrets auto tfvars example

### DIFF
--- a/environments/target/secrets.auto.tfvars
+++ b/environments/target/secrets.auto.tfvars
@@ -1,0 +1,3 @@
+db_password  = "타깃-RDS-비밀번호"
+src_password = "소스-RDS-비밀번호"
+tgt_password = "타깃-RDS-비밀번호"


### PR DESCRIPTION
## Summary
- add secrets.auto.tfvars to specify placeholder passwords for target environment

## Testing
- `terraform -v` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*
- `terraform fmt -recursive` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c2bae4ac83278b00a7f6ed3d4cc5